### PR TITLE
Remove explicit loopback binding and access MariaDB on docker bridge IP

### DIFF
--- a/commands
+++ b/commands
@@ -92,7 +92,7 @@ case "$1" in
 
     database_pw=$(cat "$HOME/pass_$APP")
 
-    echo "mysql://${APP}:${database_pw}@${private_ip}:${port}/${database}"
+    echo "mysql://${APP}:${database_pw}@172.17.42.1:${port}/${database}"
     ;;
   mariadb:create)
     check_container
@@ -106,7 +106,7 @@ case "$1" in
     $manage create "$database" "$admin_pw" "$new_password"
 
     if [[ -d "$DOKKU_ROOT/$APP" ]]; then
-      dokku config:set "$APP" DATABASE_URL="mysql://${APP}:${new_password}@${private_ip}:${port}/${database}"
+      dokku config:set "$APP" DATABASE_URL="mysql://${APP}:${new_password}@172.17.42.1:${port}/${database}"
     fi
     ;;
 
@@ -138,7 +138,7 @@ case "$1" in
     if [[ "$id" != "" ]]; then
       echo "Mariadb container already running with ID: ${id}"
     else
-      docker run -d -p 127.0.0.1:3306:3306 -v "$HOME/data":"/var/lib/mysql" -v "$HOME/shared":"/shared" "$db_image" start
+      docker run -d -p 3306:3306 -v "$HOME/data":"/var/lib/mysql" -v "$HOME/shared":"/shared" "$db_image" start
     fi
     ;;
 


### PR DESCRIPTION
Keeping IP and port the same ensures DB connections survive reboots. kloadut/dokku-md-plugin uses this approach to fix IP but can’t fix the port since it starts multiple MariaDB servers.

For more info: https://github.com/Kloadut/dokku-pg-plugin/issues/12
